### PR TITLE
Added variable user_group_ids 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,8 +21,8 @@ resource "aws_elasticache_subnet_group" "this" {
 }
 
 resource "aws_elasticache_replication_group" "this" {
-  replication_group_id          = var.application_name
-  description                   = "Replication group for ElastiCache"
+  replication_group_id = var.application_name
+  description          = "Replication group for ElastiCache"
 
   engine               = "redis"
   engine_version       = var.engine_version
@@ -41,6 +41,7 @@ resource "aws_elasticache_replication_group" "this" {
 
   subnet_group_name  = aws_elasticache_subnet_group.this.name
   security_group_ids = [aws_security_group.this.id]
+  user_group_ids     = var.user_group_ids
 }
 
 /*

--- a/variables.tf
+++ b/variables.tf
@@ -5,17 +5,17 @@ variable "application_name" {
 
 variable "security_group_ids" {
   description = "Security Groups that are allowed to access the cluster"
-  type = list(string)
+  type        = list(string)
 }
 
 variable "vpc_id" {
   description = "The ID of the VPC the ElastiCache cluster will be in"
-  type = string
+  type        = string
 }
 
 variable "subnet_ids" {
   description = "Subnets where the elasticache will be placed"
-  type = list(string)
+  type        = list(string)
 }
 
 variable "node_type" {
@@ -27,21 +27,28 @@ variable "node_type" {
 
 variable "availability_zones" {
   description = "Availability zones to run in"
-  type = list(string)
+  type        = list(string)
 
   default = []
 }
 
 variable "engine_version" {
   description = "The version of redis to use"
-  type = string
+  type        = string
 
   default = "5.0.5"
 }
 
 variable "parameter_group_name" {
   description = "Parameter group to use for the engine"
-  type = string
+  type        = string
 
   default = "default.redis5.0"
+}
+
+variable "user_group_ids" {
+  description = "User Group ID to associate with the replication group (Optional)"
+  type        = list(string)
+
+  default = null
 }


### PR DESCRIPTION
Added variable user_group_ids in order to reference an aws_elasticache_user_group to the elasticache.
This is needed to configure Role-based Access control (RBAC) to controll access to the cache